### PR TITLE
Fix getParameter for aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ $ npm install -g serverless
 After you have it installed, just deploy your function to the main region, specifying as target the replication region. For instance, to replicate from `us-east-1` to `us-west-2`:
 
 ```bash
-$ sls deploy --region us-east-1  --target=us-west-2
+$ sls deploy --region us-east-1  --param="target=eu-west-1"
 ```
 
 You can establish two way replication by deploying the same lambda to the target region:
 
 ```bash
-$ sls deploy --region us-west-2  --target=us-east-1
+$ sls deploy --region us-west-2  --param="target=eu-west-1"
 ```
 
 If you are using two way replication, there's logic in place to avoid the "ping pong" effect, where a region replicating to another causes the replication to happen in the other direction. Currenlty, the logic is just based on value and type for a given parameter. If they already exist in the target region, and their value match, replication is not performed.

--- a/handler.js
+++ b/handler.js
@@ -69,12 +69,16 @@ exports.replicate = async (event, context, callback) => {
   console.log(JSON.stringify(event))
   try {
     if (event.detail.operation in operations) {
-      const success = await operations[event.detail.operation](event)
-      if (success) {
-        console.log(`${event.detail.operation} result:\n${JSON.stringify(success)}`)
+      if (event.detail.name.includes('/prod/')) {
+        const success = await operations[event.detail.operation](event)
+        if (success) {
+          console.log(`${event.detail.operation} result:\n${JSON.stringify(success)}`)
+        }
+      } else {
+        console.log(`Unknown operation "${event.detail.operation}":\n ${JSON.stringify(event)}`)
       }
     } else {
-      console.log(`Unknown operation "${event.detail.operation}":\n ${JSON.stringify(event)}`)
+      console.log('Only Production Resources are allowed for Replication')
     }
   } catch (error) {
     console.log(`Operation failed for\n ${JSON.stringify(event)}\n${JSON.stringify(error)}`)

--- a/handler.js
+++ b/handler.js
@@ -1,5 +1,4 @@
-const AWSXRay = require('aws-xray-sdk-core')
-const AWS = AWSXRay.captureAWS(require('aws-sdk'))
+const AWS = require('aws-sdk')
 
 const sourceSSM = new AWS.SSM({
   region: process.env.AWS_DEFAULT_REGION
@@ -33,8 +32,10 @@ const update = async (event) => {
 
   const targetParam = await checkTarget(event)
   if (!targetParam || targetParam.Parameter.Value !== sourceParam.Parameter.Value || targetParam.Parameter.Type !== sourceParam.Parameter.Type) {
-    // remove the version
+    // remove unused Keys
     delete sourceParam.Parameter.Version
+    delete sourceParam.Parameter.ARN
+    delete sourceParam.Parameter.LastModifiedDate
     // enable overwrites
     sourceParam.Parameter.Overwrite = true
     return targetSSM.putParameter(sourceParam.Parameter).promise()

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,7 @@ provider:
 functions:
   replicate:
     environment: 
-      AWS_TARGET_REGION: ${opt:target}
+      AWS_TARGET_REGION: ${param:target}
     handler: handler.replicate
     events:
       - cloudwatchEvent:

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: parameter-store-replicator
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs16.x
   iamRoleStatements:
     - Effect: "Allow"
       Action:
@@ -25,4 +25,3 @@ functions:
               - "aws.ssm"
             detail-type:
               - "Parameter Store Change"
-

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-service: parameter-store-replicator 
+service: ParamStoreReplicator 
 
 provider:
   name: aws


### PR DESCRIPTION
- aws-sdk for JavaScript has some changed schema for **`ssm.getParameter`** request.
- Schema changes added **`ARN`** & **`LastModifiedDate`** in the Request.
- Version key was deleted, but AWS didn't recognise schema for the `putParameter` call.
- This fix remediates the issue & has been tested.